### PR TITLE
4.1.0 fix

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/AbstractCommentBuilder.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/AbstractCommentBuilder.java
@@ -111,6 +111,7 @@ public abstract class AbstractCommentBuilder {
         root.put("commentNoIssue", gitLabPluginConfiguration.commentNoIssue());
         root.put("sonarUrl", gitLabPluginConfiguration.baseUrl());
         root.put("publishMode", analysisMode.isPublish());
+        root.put("projectKey", gitLabPluginConfiguration.projectKey());
         // Report
         root.put("revision", revision);
         Arrays.stream(Severity.values()).forEach(severity -> root.put(severity.name(), severity));

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4Wrapper.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4Wrapper.java
@@ -285,6 +285,12 @@ public class GitLabApiV4Wrapper implements IGitLabApiWrapper {
 
     private void createReviewDiscussion(String fullPath, Integer lineNumber, String body) throws IOException {
         Integer projectId = gitLabProject.getId();
+
+        Integer mergeRequestTargetProjectId = config.mergeRequestTargetProjectId();
+        if( mergeRequestTargetProjectId != -1  && !projectId.equals(mergeRequestTargetProjectId)){
+            projectId = mergeRequestTargetProjectId;
+        }
+
         int mergeRequestIid = config.mergeRequestIid();
 
         checkArgument(mergeRequestIid != -1, "The merge request iid must be provided.");

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
@@ -68,6 +68,7 @@ public class GitLabPlugin implements Plugin {
     public static final String GITLAB_DISABLE_PROXY = "sonar.gitlab.disable_proxy";
     public static final String GITLAB_MERGE_REQUEST_DISCUSSION = "sonar.gitlab.merge_request_discussion";
     public static final String GITLAB_CI_MERGE_REQUEST_IID = "sonar.gitlab.ci_merge_request_iid";
+    public static final String GITLAB_CI_MERGE_REQUEST_PROJECT_ID = "sonar.gitlab.ci_merge_request_project_id";
 
     public static final String CATEGORY = "gitlab";
     public static final String SUBCATEGORY = "reporting";
@@ -166,8 +167,11 @@ public class GitLabPlugin implements Plugin {
                         PropertyDefinition.builder(GITLAB_CI_MERGE_REQUEST_IID).name("Merge Request IID").description("The IID of the merge request if it’s pipelines for merge requests")
                                 .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.INTEGER)
                                 .defaultValue(String.valueOf(-1))
-                                .index(35).build()
-
+                                .index(35).build(),
+                        PropertyDefinition.builder(GITLAB_CI_MERGE_REQUEST_PROJECT_ID).name("Merge Request TARGET PROJECT ID").description("The ID of the merge request target project if it’s pipelines for merge requests")
+                                .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.INTEGER)
+                                .defaultValue(String.valueOf(-1))
+                                .index(36).build()
                 );
     }
 

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -278,4 +278,8 @@ public class GitLabPluginConfiguration {
         return configuration.getInt(GitLabPlugin.GITLAB_CI_MERGE_REQUEST_IID).orElse(-1);
     }
 
+    public String projectKey() {
+        return configuration.get("sonar.projectKey").orElse(null);
+    }
+
 }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -282,4 +282,8 @@ public class GitLabPluginConfiguration {
         return configuration.get("sonar.projectKey").orElse(null);
     }
 
+    public int mergeRequestTargetProjectId() {
+        return configuration.getInt(GitLabPlugin.GITLAB_CI_MERGE_REQUEST_PROJECT_ID).orElse(-1);
+    }
+
 }

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
@@ -48,6 +48,7 @@ public class GitLabPluginConfigurationTest {
     public void before() {
         settings = new MapSettings(new PropertyDefinitions(GitLabPlugin.definitions()));
         settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://myserver");
+        settings.setProperty(CoreProperties.PROJECT_KEY_PROPERTY, "myProject");
         config = new GitLabPluginConfiguration(settings.asConfig(), new System2());
     }
 
@@ -64,6 +65,16 @@ public class GitLabPluginConfigurationTest {
         settings.removeProperty("sonar.host.url");
         config = new GitLabPluginConfiguration(settings.asConfig(), new System2());
         Assertions.assertThat(config.baseUrl()).isEqualTo("http://localhost:9000/");
+    }
+
+    @Test
+    public void testProjectKey() {
+        Assertions.assertThat(config.projectKey()).isEqualTo("myProject");
+
+        settings.removeProperty(CoreProperties.PROJECT_KEY_PROPERTY);
+        settings.setProperty("sonar.projectKey", "myProject2");
+        config = new GitLabPluginConfiguration(settings.asConfig(), new System2());
+        Assertions.assertThat(config.projectKey()).isEqualTo("myProject2");
     }
 
     @Test


### PR DESCRIPTION
Two features added :
1. projectKey in gitlabPluginConfiguration
2. GITLAB_CI_MERGE_REQUEST_PROJECT_ID to enable starting a thread at the target project's merge request in the pull request situation