### PR TITLE
add template variable projectKey 

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/AbstractCommentBuilder.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/AbstractCommentBuilder.java
@@ -111,6 +111,7 @@ public abstract class AbstractCommentBuilder {
         root.put("commentNoIssue", gitLabPluginConfiguration.commentNoIssue());
         root.put("sonarUrl", gitLabPluginConfiguration.baseUrl());
         root.put("publishMode", analysisMode.isPublish());
+        root.put("projectKey", gitLabPluginConfiguration.projectKey());
         // Report
         root.put("revision", revision);
         Arrays.stream(Severity.values()).forEach(severity -> root.put(severity.name(), severity));

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -278,4 +278,8 @@ public class GitLabPluginConfiguration {
         return configuration.getInt(GitLabPlugin.GITLAB_CI_MERGE_REQUEST_IID).orElse(-1);
     }
 
+    public String projectKey() {
+        return configuration.get("sonar.projectKey").orElse(null);
+    }
+
 }

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
@@ -48,6 +48,7 @@ public class GitLabPluginConfigurationTest {
     public void before() {
         settings = new MapSettings(new PropertyDefinitions(GitLabPlugin.definitions()));
         settings.setProperty(CoreProperties.SERVER_BASE_URL, "http://myserver");
+        settings.setProperty(CoreProperties.PROJECT_KEY_PROPERTY, "myProject");
         config = new GitLabPluginConfiguration(settings.asConfig(), new System2());
     }
 
@@ -64,6 +65,16 @@ public class GitLabPluginConfigurationTest {
         settings.removeProperty("sonar.host.url");
         config = new GitLabPluginConfiguration(settings.asConfig(), new System2());
         Assertions.assertThat(config.baseUrl()).isEqualTo("http://localhost:9000/");
+    }
+
+    @Test
+    public void testProjectKey() {
+        Assertions.assertThat(config.projectKey()).isEqualTo("myProject");
+
+        settings.removeProperty(CoreProperties.PROJECT_KEY_PROPERTY);
+        settings.setProperty("sonar.projectKey", "myProject2");
+        config = new GitLabPluginConfiguration(settings.asConfig(), new System2());
+        Assertions.assertThat(config.projectKey()).isEqualTo("myProject2");
     }
 
     @Test


### PR DESCRIPTION
In order to use projectKey in comment template, this variable is added. It can be used in the situation that a sonar report link need to be added in the global comment,  just like this:
Sonarqube report url: ${sonarUrl}dashboard?id=${projectKey}
