### PR TITLE
add plugin property ci_merge_request_project_id to create discussion in pull request situation

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4Wrapper.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4Wrapper.java
@@ -285,6 +285,12 @@ public class GitLabApiV4Wrapper implements IGitLabApiWrapper {
 
     private void createReviewDiscussion(String fullPath, Integer lineNumber, String body) throws IOException {
         Integer projectId = gitLabProject.getId();
+
+        Integer mergeRequestTargetProjectId = config.mergeRequestTargetProjectId();
+        if( mergeRequestTargetProjectId != -1  && !projectId.equals(mergeRequestTargetProjectId)){
+            projectId = mergeRequestTargetProjectId;
+        }
+
         int mergeRequestIid = config.mergeRequestIid();
 
         checkArgument(mergeRequestIid != -1, "The merge request iid must be provided.");

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
@@ -68,6 +68,7 @@ public class GitLabPlugin implements Plugin {
     public static final String GITLAB_DISABLE_PROXY = "sonar.gitlab.disable_proxy";
     public static final String GITLAB_MERGE_REQUEST_DISCUSSION = "sonar.gitlab.merge_request_discussion";
     public static final String GITLAB_CI_MERGE_REQUEST_IID = "sonar.gitlab.ci_merge_request_iid";
+    public static final String GITLAB_CI_MERGE_REQUEST_PROJECT_ID = "sonar.gitlab.ci_merge_request_project_id";
 
     public static final String CATEGORY = "gitlab";
     public static final String SUBCATEGORY = "reporting";
@@ -166,8 +167,11 @@ public class GitLabPlugin implements Plugin {
                         PropertyDefinition.builder(GITLAB_CI_MERGE_REQUEST_IID).name("Merge Request IID").description("The IID of the merge request if it’s pipelines for merge requests")
                                 .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.INTEGER)
                                 .defaultValue(String.valueOf(-1))
-                                .index(35).build()
-
+                                .index(35).build(),
+                        PropertyDefinition.builder(GITLAB_CI_MERGE_REQUEST_PROJECT_ID).name("Merge Request TARGET PROJECT ID").description("The ID of the merge request target project if it’s pipelines for merge requests")
+                                .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.INTEGER)
+                                .defaultValue(String.valueOf(-1))
+                                .index(36).build()
                 );
     }
 

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -278,4 +278,8 @@ public class GitLabPluginConfiguration {
         return configuration.getInt(GitLabPlugin.GITLAB_CI_MERGE_REQUEST_IID).orElse(-1);
     }
 
+    public int mergeRequestTargetProjectId() {
+        return configuration.getInt(GitLabPlugin.GITLAB_CI_MERGE_REQUEST_PROJECT_ID).orElse(-1);
+    }
+
 }


### PR DESCRIPTION
# Problem
In the pull request situation,  when the merge request discussion is enabled and a review discussion need to be created, an error like this occurs:
`ERROR:Error during SonarQube Scanner execution` 
`ERROR: SonarQube failed to complete the review of this commit: Unable to create or update review comment in file *.java at line 124`
`ERROR: Caused by: Unable to create or update review comment in file *.java at line 124`
`ERROR: Caused by: https://gitlab.com/api/v4/projects/944/merge_requests/22/versions`

It is because the merge source project id is not equal to target project id, and the sonar-gitlab-plugin tries to create the discussion on the merge request of the source project even it does not exist. The merge request is on the target project. 

# Solution
The plugin property ci_merge_request_project_id is added and the method createReviewDiscussion in GitLabApiV4Wrapper is overwritten. When the sonar.gitlab.ci_merge_request_project_id  is configured and not equals to the source project id,  the review discussion will be created on merge request of the target project. 

For example, it can be used as:
`sonar-scanner -Dsonar.branch.name=$CI_COMMIT_REF_NAME -Dsonar.gitlab.ci_merge_request_iid=$CI_MERGE_REQUEST_IID -Dsonar.gitlab.ci_merge_request_project_id=$CI_MERGE_REQUEST_PROJECT_ID`

